### PR TITLE
Fix layout and spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This file can be edited to suit your needs, and the different inputs there will 
 
 ![Inputs Screenshot](images/inputs.png)
 
-# Support for other languages
+# Support for Other Languages
 
 NEO smart contracts can be coded in many different languages, and in theory, this compiler already supports any language as long as a `.neomap` file exists in the same directory as the `.avm` file.
 However, since only NeoN was modified to emit those map files during compilation, to add other languages it would be necessary to modify other compilers to emit a `.neomap`.

--- a/README.md
+++ b/README.md
@@ -19,45 +19,50 @@
 
 ---
 
-# Overview
+## Overview
 A suite of development tools for NEO smart contracts.  
 Includes a cli disassembler and a GUI debugger. A helper library that helps loading `.avm` files and create and load `.neomap` files is also included, and can be used to create other dev tools.
 
 ![Debugger Screenshot](images/debugger.png)
 
-## How this works
+### How this works
+
 1. A modified NEO compiler to compile C# into an `.avm` file and, at same time, emit a `.neomap` file.
 2. A debugger IDE will load the `.avm` and disassemble it into readable opcodes.
 3. The debugger IDE can also run or step through either the assembly code or the original source (if the `.neomap` file is present in same directory as the `.avm`)
 4. The debugger will also emulate the smart contracts' API that interacts with the Blockchain (like Storage, Transactions, Blocks)
 
-## Current Features
+### Current Features
+
 - Supports any NEO `.avm`, regardless of the language / compiler used
 - Source viewer with syntax highlight powered by ScintillaNET
 - Run, step and set breakpoints in order to debug smart contracts
 - Toggle between source code and assembly code
 
-## Limitations
+### Limitations
+
 - Debugging ASM and C# only for now (see section below how to add new languages)
 - Windows only for now, using .NET Framework / Winforms / ScintillaNET
 - Smart contract source is limited to a single file for now
 - Not possible yet to inspect variable values
 - Most NEO syscalls / APIs not supported yet (work in progress)
 
-# Usage
+
+## Usage
 
 Open the `.avm` file in the NEO-dbg GUI application.
 This will show either assembly code for the `.avm` or C# if a debug map file was found.
 Currently the only way to generate a `.neomap` file is to compile the smart contracts with the modified NeoN compiler included in this repository.
 
-## Shortcuts
+### Shortcuts
+
 | Key           | Action                                    | Comments                                      |
 | ------------- |:------------------------------------------| :---------------------------------------------|
 | F5            | Executes the smart contract               |                                               |
 | F10           | Steps through the smart contract          |                                               |
 | F12           | Toggles between assembly and source code  | Only works when a `.neomap` file is available |
 
-## Smart Contract Inputs
+### Smart Contract Inputs
 
 A single smart contract can have different results and behaviours, depending on the inputs passed to it.
 
@@ -67,13 +72,15 @@ This file can be edited to suit your needs, and the different inputs there will 
 
 ![Inputs Screenshot](images/inputs.png)
 
-# Support for Other Languages
+
+## Support for Other Languages
 
 NEO smart contracts can be coded in many different languages, and in theory, this compiler already supports any language as long as a `.neomap` file exists in the same directory as the `.avm` file.
 However, since only NeoN was modified to emit those map files during compilation, to add other languages it would be necessary to modify other compilers to emit a `.neomap`.
 The `.neomap` file format is simple; for each line you need to list a starting offset, ending offset, the source line and the corresponding source file, all values separated by a comma.
 
-# Roadmap
+
+## Roadmap
 - Customize smart contract arguments
 - Stack viewer
 - Storage emulation
@@ -81,7 +88,8 @@ The `.neomap` file format is simple; for each line you need to list a starting o
 - Persistency of smart contract storage to disk
 - Debugger map generation for Java / Python / others
 
-# Credits and License #
+
+## Credits and License
 
 Created by Sérgio Flores (<http://lunarlabs.pt/>).
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # NEO-debugger-tools
-Suite of development tools for NEO smart contracts.
-Includes a cli disassembler and a GUI debugger. An helper library that helps loading .AVM files and create and load .neomap files is also included, and can be used to create other dev tools.
+A suite of development tools for NEO smart contracts.  
+Includes a cli disassembler and a GUI debugger. A helper library that helps loading `.avm` files and create and load `.neomap` files is also included, and can be used to create other dev tools.
 
 ![Debugger Screenshot](images/debugger.png)
 
 ## How this works
-1. A modified NEO compiler to compile C# into an .avm file and at same time emit a .neomap file.
-2. A debugger IDE will load the .avm and disassemble it into readable opcodes.
-3. The debugger IDE can also run or step through either the assembly code or the original source (if the .neomap file is present in same directory as the .avm)
-4. The debugger will also emulate the smart contracts API that interacts with the Blockchain (like Storage, Transactions, Blocks)
+1. A modified NEO compiler to compile C# into an `.avm` file and, at same time, emit a `.neomap` file.
+2. A debugger IDE will load the `.avm` and disassemble it into readable opcodes.
+3. The debugger IDE can also run or step through either the assembly code or the original source (if the `.neomap` file is present in same directory as the `.avm`)
+4. The debugger will also emulate the smart contracts' API that interacts with the Blockchain (like Storage, Transactions, Blocks)
 
 ## Features
-- Supports any NEO .AVM, regardless of the language / compiler used
+- Supports any NEO `.avm`, regardless of the language / compiler used
 - Source viewer with syntax highlight powered by ScintillaNET
 - Run, step and set breakpoints in order to debug smart contracts
 - Toggle between source code and assembly code
@@ -21,26 +21,26 @@ Includes a cli disassembler and a GUI debugger. An helper library that helps loa
 - Windows only for now, using .NET Framework / Winforms / ScintillaNET
 - Smart contract source is limited to a single file for now
 - Not possible yet to inspect variable values
-- Most NEO syscalls/APIs not supported yet (work in progress)
+- Most NEO syscalls / APIs not supported yet (work in progress)
 
 # How to use
 
-Open the .avm file in the NEO-dbg GUI application.
-This will show either assembly code for the .avm or C# if a debug map file was found.
-Currently the only way to generate a .neomap file is to compile the smart contracts with the modified NeoN compiler include in this repository.
+Open the `.avm` file in the NEO-dbg GUI application.
+This will show either assembly code for the `.avm` or C# if a debug map file was found.
+Currently the only way to generate a `.neomap` file is to compile the smart contracts with the modified NeoN compiler included in this repository.
 
 ## Shortcuts
-| Key        | Action | Comments  |
-| ------------- |:-------------:| -----:|
-| F5 | Executes the smart contract ||
-| F10 | Steps through the smart contract ||
-| F12 | Toggle between assembly and source  code | Only works when a .neomap file is available |
+| Key           | Action                                    | Comments                                      |
+| ------------- |:------------------------------------------| :---------------------------------------------|
+| F5            | Executes the smart contract               |                                               |
+| F10           | Steps through the smart contract          |                                               |
+| F12           | Toggles between assembly and source code  | Only works when a `.neomap` file is available |
 
 ## Smart Contract Inputs
 
-A single smart contract can have different results and behaviours depending on the inputs passed to it.
+A single smart contract can have different results and behaviours, depending on the inputs passed to it.
 
-So when debugging a contract it is necessary to be able to specify the inputs. Currently this is done via a contract.json that resides in the same folder as the debugger executable.
+So, when debugging a contract, it is necessary to be able to specify the inputs. Currently this is done via a `contract.json` that resides in the same folder as the debugger executable.
 
 This file can be edited to suit your needs, and the different inputs there will appear every time you use the debugger to execute the contract.
 
@@ -48,9 +48,9 @@ This file can be edited to suit your needs, and the different inputs there will 
 
 # Support for other languages
 
-NEO smart contracts can be coded in many different languages, and in theory, this compiler already supports any language as long as a .neomap file exists in the same directory as the .avm file.
-However since only NeoN was modified to emit those map files during compilation, to add other languages it would be necessary to modify other compilers to emit a .neomap.
-The .neomap file format is simple, for each line you need to list a starting offset, ending offset, the source line and the corresponding source file, all values separated by a comma.
+NEO smart contracts can be coded in many different languages, and in theory, this compiler already supports any language as long as a `.neomap` file exists in the same directory as the `.avm` file.
+However, since only NeoN was modified to emit those map files during compilation, to add other languages it would be necessary to modify other compilers to emit a `.neomap`.
+The `.neomap` file format is simple; for each line you need to list a starting offset, ending offset, the source line and the corresponding source file, all values separated by a comma.
 
 # Roadmap
 - Customize smart contract arguments
@@ -65,6 +65,6 @@ The .neomap file format is simple, for each line you need to list a starting off
 Created by Sérgio Flores (<http://lunarlabs.pt/>).
 
 
-Credits also go to the NEO team(<http://neo.org>), as a large part  of this work was based on their [NEO compiler](https://github.com/neo-project/neo-compiler) and [NEO VM](https://github.com/neo-project/neo-vm).
+Credits also go to the NEO team(<http://neo.org>), as a large part of this work was based on their [NEO compiler](https://github.com/neo-project/neo-compiler) and [NEO VM](https://github.com/neo-project/neo-vm).
 
-This project is released under the MIT license,  see `LICENSE.md` for more details.
+This project is released under the MIT license, see `LICENSE.md` for more details.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,25 @@
-# NEO-debugger-tools
+<p align="center">
+  <img 
+    src="http://res.cloudinary.com/vidsy/image/upload/v1503160820/CoZ_Icon_DARKBLUE_200x178px_oq0gxm.png" 
+    width="125px"
+  >
+</p>
+
+<h1 align="center">neo-debugger-tools</h1>
+
+<p align="center">
+  NEO debugger tools for <b>NEO</b> smart contracts.
+</p>
+
+- [Overview](#overview)
+- [Usage](#usage)
+- [Support for Other Languages](#support-for-other-languages)
+- [Roadmap](#roadmap)
+- [Credits and License](#credits-and-license)
+
+---
+
+# Overview
 A suite of development tools for NEO smart contracts.  
 Includes a cli disassembler and a GUI debugger. A helper library that helps loading `.avm` files and create and load `.neomap` files is also included, and can be used to create other dev tools.
 
@@ -10,7 +31,7 @@ Includes a cli disassembler and a GUI debugger. A helper library that helps load
 3. The debugger IDE can also run or step through either the assembly code or the original source (if the `.neomap` file is present in same directory as the `.avm`)
 4. The debugger will also emulate the smart contracts' API that interacts with the Blockchain (like Storage, Transactions, Blocks)
 
-## Features
+## Current Features
 - Supports any NEO `.avm`, regardless of the language / compiler used
 - Source viewer with syntax highlight powered by ScintillaNET
 - Run, step and set breakpoints in order to debug smart contracts
@@ -23,7 +44,7 @@ Includes a cli disassembler and a GUI debugger. A helper library that helps load
 - Not possible yet to inspect variable values
 - Most NEO syscalls / APIs not supported yet (work in progress)
 
-# How to use
+# Usage
 
 Open the `.avm` file in the NEO-dbg GUI application.
 This will show either assembly code for the `.avm` or C# if a debug map file was found.
@@ -63,7 +84,6 @@ The `.neomap` file format is simple; for each line you need to list a starting o
 # Credits and License #
 
 Created by Sérgio Flores (<http://lunarlabs.pt/>).
-
 
 Credits also go to the NEO team(<http://neo.org>), as a large part of this work was based on their [NEO compiler](https://github.com/neo-project/neo-compiler) and [NEO VM](https://github.com/neo-project/neo-vm).
 


### PR DESCRIPTION
Hi, few suggestions:
- Added some markdown magic so the `.avm` and stuff pop out more;
- Fixed some double spaces or typos;
- Improved the layout of the table, both in a text editor and the output.

Nice job on the debugger tool!