### PR TITLE
A build failure fixed, readme fixed. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,3 +237,4 @@ ModelManifest.xml
 
 # Paket dependency manager
 .paket/paket.exe
+/NEO-IDE/Output/Site/netcoreapp2.0

--- a/NEO-Emulator/API/Blockchain.cs
+++ b/NEO-Emulator/API/Blockchain.cs
@@ -138,7 +138,7 @@ namespace Neo.Emulator.API
                 {
                     block = new Block();
                     block.timestamp = 1506787300;
-                    blockchain.blocks[height] = block;
+                    blockchain.blocks[height+1] = block;
                 }
             }
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Includes a cli disassembler and a GUI debugger. A helper library that helps load
 
 ### Setup 
 1. Get this code and open the solution in Visual Studio.
-2. Compile the solution and find the compiled NEON.exe path (should be a sub folder bin/debug under the solution folder).
+2. Compile the solution and find the compiled NEON.exe path (should be in $(SolutionPath)\NEO-Compiler\bin\Debug).
 3. Replace the path of your old NEON compiler to the new compiler path. 
 4. When you compile a smart contract, it will accordingly use the debugger compiler and produce (next to the`.avm`) the map file which you need to step through the code.
 

--- a/neo-dev-tools.sln
+++ b/neo-dev-tools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NEO-Compiler", "NEO-Compiler\NEO-Compiler.csproj", "{36E1CCD1-3C95-459D-88D1-6F14E07EAEC9}"
 EndProject
@@ -10,6 +10,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NEO-CLI-Disassembler", "NEO-CLI-Disassembler\NEO-CLI-Disassembler.csproj", "{4AB8DA86-649F-4F8C-A448-B3F10B8D3350}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ICO-Template", "ICO-Template\ICO-Template.csproj", "{ACD39528-CE59-4A17-B6ED-9C237D2A0E82}"
+	ProjectSection(ProjectDependencies) = postProject
+		{36E1CCD1-3C95-459D-88D1-6F14E07EAEC9} = {36E1CCD1-3C95-459D-88D1-6F14E07EAEC9}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NEO-Emulator", "NEO-Emulator\NEO-Emulator.csproj", "{372429C2-71BE-41C2-92D0-5A9187BC238A}"
 EndProject


### PR DESCRIPTION
Clean Solution -> Rebuild Solution was failing while building ICO-Template because NEO-Compiler hadn't generated neon.exe yet.

neon.exe path changed in readme