### PR TITLE
Fake transfers for unchecked amounts

### DIFF
--- a/ICO-Template/IcoContract.cs
+++ b/ICO-Template/IcoContract.cs
@@ -144,10 +144,11 @@ namespace Neo.SmartContract
         public static bool Transfer(byte[] from, byte[] to, BigInteger value)
         {
             if (value <= 0) return false;
+            if (to.Length != 20) return false;
             if (!Runtime.CheckWitness(from)) return false;
-            if (from == to) return true;
             BigInteger from_value = Storage.Get(Storage.CurrentContext, from).AsBigInteger();
             if (from_value < value) return false;
+            if (from == to) return true;
             if (from_value == value)
                 Storage.Delete(Storage.CurrentContext, from);
             else


### PR DESCRIPTION
* Check `to` length: Avoid tokens burn and write junk on the storage.
* Fake transfers for unchecked amounts (described here: https://github.com/neonexchange/neo-ico-template/pull/21).